### PR TITLE
[Issue - 13] 일과 시간이 특정 시간보다 작은 경우 블록안에 텍스트 표시하지 않기

### DIFF
--- a/my-garden-fe/src/components/dailyRoutine/draw/DrawDailyRoutine.vue
+++ b/my-garden-fe/src/components/dailyRoutine/draw/DrawDailyRoutine.vue
@@ -143,8 +143,8 @@ const afternoonSchedule = computed(() => {
         <div v-for="(block, index) in afternoonSchedule" :key="`afternoon-${index}`"
              :style="blockStyle(block, 'afternoon')"
              class="time-block my-tooltip">
-          <div v-if="calculateDuration(block) >= 20">{{ block.displayStartTime }} ~ {{ block.displayEndTime }} ::
-            {{ block.routineType }}
+          <div v-if="calculateDuration(block) >= 20">
+            {{ block.displayStartTime }} ~ {{ block.displayEndTime }} :: {{ block.routineType }}
           </div>
           <span class="tooltiptext tooltip-right">
             {{ block.routineDescription === "" ? block.routineType : block.routineDescription }}


### PR DESCRIPTION
일과 시간이 특정 시간보다 작은 경우 블록안에 텍스트 표시하지 않기

---

1. 20px 이하 블록은 텍스트가 나오지 않도록 수정

close #13