### PR TITLE
하루일과 Tooltip의 위치가 이상하게 나오는 증상

### DIFF
--- a/my-garden-fe/src/components/dailyRoutine/draw/ScheduleSection.vue
+++ b/my-garden-fe/src/components/dailyRoutine/draw/ScheduleSection.vue
@@ -16,6 +16,8 @@ const props = defineProps({
 });
 
 const hoverTimeBlockId = ref(0);
+const morningStrings = ['오전', 'AM', 'am', 'morning'];
+const afternoonStrings = ['오후', 'PM', 'pm', 'afternoon'];
 
 function blockStyle(block, partOfDay) {
   const duration = calculateDuration(block);
@@ -38,8 +40,6 @@ function calculateDuration(block) {
 }
 
 function getOffset(partOfDay) {
-  const afternoonStrings = ['오후', 'PM', 'pm', 'afternoon'];
-
   // 720 === 1px per minute, 12 hours * 60 minutes
   return afternoonStrings.includes(partOfDay) ? 720 : 0; // 12:00 ~ 24:00
 }
@@ -60,13 +60,17 @@ function updateBlock(block) {
   store.commit('setEditBlock', block);
 }
 
+function convertEng(partOfDay) {
+  return morningStrings.includes(partOfDay) ? 'morning' : 'afternoon';
+}
+
 </script>
 
 <template>
   <div id="morning-schedule" class="schedule-section">
     <div class="schedule-label">{{ partOfDay }}</div>
     <div class="schedule-half">
-      <div v-for="(block, index) in scheduleArray" :key="`${index}`"
+      <div v-for="block in scheduleArray" :key="`${convertEng(partOfDay)}-${block.id}`"
            :style="blockStyle(block, partOfDay)" class="time-block"
            @click="updateBlock(block)"
            @mouseleave="hoverTimeBlockId = 0" @mouseover="hoverTimeBlockId = block.id">


### PR DESCRIPTION
하루일과 Tooltip의 위치가 이상하게 나오는 증상

- 문제 원인
    - Vue에서 Component를 새로 그릴지 말지 판단을 할 때 key를 기준으로 판단.
    - for문에서 사용하는 key 값이 단순 index 값이라 중복되는 경우, 새로 Component가 그려지지 않고 이전 값을 그대로 사용하는 증상이 발생함 -> tooltip의 위치가 이상하게 나옴
-  해결 방안
    - for문의 key값 할당 방식 변경

close  #124