### PR TITLE
하루 일과 통계에서 전체 데이터에 대한 통계의 소수점이 길게 나오는 증상 수정

### DIFF
--- a/my-garden-fe/src/components/dailyRoutine/statistics/StatisticTable.vue
+++ b/my-garden-fe/src/components/dailyRoutine/statistics/StatisticTable.vue
@@ -49,8 +49,11 @@ function aggregateActivities(activities) {
     });
   });
 
+  aggregated.content.totalHours = aggregated.content.totalHours.toFixed(2);
   Object.keys(aggregated.content.types).forEach(type => {
-    const percentage = (aggregated.content.types[type].hours / aggregated.content.totalHours) * 100;
+    aggregated.content.types[type].hours = aggregated.content.types[type].hours.toFixed(2);
+
+    const percentage = Math.min((aggregated.content.types[type].hours / aggregated.content.totalHours) * 100, 100);
     aggregated.content.types[type].percentage = percentage.toFixed(2) + '%';
   });
 


### PR DESCRIPTION
소수점 둘째자리까지만 나오도록 수정